### PR TITLE
add T/R antenna switch driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ endif()
 # ----- Optional: full main UI (needs ALSA + ncurses + SGP4) -----------------
 
 if (ASOUND_FOUND AND NCURSES_FOUND AND SGP4SDP4_LIB)
-    add_executable(simple_sat_ops main.c prediction.c ${RADIO_SOURCES} radio_device_store.c antenna_rotator.c audio.c telemetry.c oem.c)
+    add_executable(simple_sat_ops main.c prediction.c ${RADIO_SOURCES} radio_device_store.c antenna_rotator.c tr_switch.c audio.c telemetry.c oem.c)
     target_link_directories(simple_sat_ops PRIVATE ${ASOUND_LIBRARY_DIRS} ${NCURSES_LIBRARY_DIRS})
     target_link_libraries(simple_sat_ops PRIVATE ${SGP4SDP4_LIB} ${NCURSES_LIBRARIES} m ${ASOUND_LIBRARIES} pthread)
     list(APPEND SSO_TARGETS simple_sat_ops)

--- a/main.c
+++ b/main.c
@@ -26,7 +26,10 @@
 #include "radio_device_store.h"
 #include "state.h"
 #include "prediction.h"
+#include "tr_switch.h"
 
+#include <ctype.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -61,6 +64,15 @@ void stop_tracking(state_t *state);
 void enable_wildrose_mode(state_t *state);
 int point_to_stationary_target(state_t *state, double azimuth, double elevation);
 void update_doppler_shifted_frequencies(state_t *state, double uplink_freq, double downlink_freq);
+
+// Wall-clock-independent seconds, for cadence gates and freshness
+// timestamps on subsystems like the T/R switch heartbeat parser.
+static double monotonic_seconds(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
 
 static speed_t speed_from_bps(int bps)
 {
@@ -128,6 +140,12 @@ void usage(FILE *dest, const char *name, int full)
         "Rotator overrides:\n"
         "  --rotator-target-azimuth=<deg>    Park on a fixed azimuth\n"
         "  --rotator-target-elevation=<deg>  Park on a fixed elevation\n"
+        "\n"
+        "T/R switch (UHF antenna RX/TX switch, USB-CDC):\n"
+        "  --tr-switch-device=<path>    Serial device. Default /dev/ttyACM0.\n"
+        "                               Auto-probed on start; absence is\n"
+        "                               warned-and-continued.\n"
+        "  --without-tr-switch          Skip the probe entirely.\n"
         "\n"
         "Observer location (default RAO Priddis):\n"
         "  --lat=<deg>                  Geodetic latitude\n"
@@ -381,6 +399,53 @@ void report_status(state_t *state, int *print_row, int print_col)
         clrtoeol();
     }
 
+    row++;
+    if (state->have_tr_switch) {
+        const tr_switch_t *trs = &state->tr_switch;
+        const double t_now = monotonic_seconds();
+        int stale = tr_switch_is_stale(trs, t_now);
+        const char *rfs  = (trs->state_str[0] != '\0') ? trs->state_str : "?";
+        const char *mode = (trs->mode_str [0] != '\0') ? trs->mode_str  : "?";
+
+        mvprintw(row++, col, "%15s   connected (%s)",
+                 "T/R switch",
+                 trs->device_filename ? trs->device_filename : "?");
+        clrtoeol();
+
+        // RF state. Highlight in red if we appear to be transmitting
+        // outside of a controlled burst, or if the link has gone stale
+        // (the displayed state may be from many seconds ago).
+        int rfs_warn = (strcmp(rfs, "TX") == 0) || stale;
+        if (rfs_warn) attron(COLOR_PAIR(1));
+        mvprintw(row++, col, "%15s   %s%s",
+                 "RF state", rfs, stale ? "  (stale)" : "");
+        if (rfs_warn) attroff(COLOR_PAIR(1));
+        clrtoeol();
+
+        // Mode. Anything other than AUTO is yellow so the operator
+        // notices the slide switch / serial override mismatch.
+        int mode_warn = (strcmp(mode, "AUTO") != 0);
+        if (mode_warn) attron(COLOR_PAIR(2));
+        mvprintw(row++, col, "%15s   %s", "mode", mode);
+        if (mode_warn) attroff(COLOR_PAIR(2));
+        clrtoeol();
+
+        // last_tx_ago_s: NAN = field absent (firmware pre-extension)
+        // or unparseable, +inf = firmware-reported "never". Both render
+        // as the placeholder so the operator can tell the firmware
+        // never saw a TX from the current value alone.
+        if (isnan(trs->last_tx_ago_s) || isinf(trs->last_tx_ago_s)) {
+            mvprintw(row++, col, "%15s   --", "last TX");
+        } else {
+            mvprintw(row++, col, "%15s   %.1f s ago",
+                     "last TX", trs->last_tx_ago_s);
+        }
+        clrtoeol();
+    } else {
+        mvprintw(row++, col, "%15s   %s", "T/R switch", "* not connected *");
+        clrtoeol();
+    }
+
     *print_row = row;
 }
 
@@ -514,6 +579,21 @@ int main(int argc, char **argv)
             return EXIT_FAILURE;
         }
         state.have_antenna_rotator = 1;
+    }
+
+    // T/R antenna switch — auto-probe. Absent / inaccessible device
+    // is a one-line warning, not an error; the UI panel will render
+    // "not connected" until the switch shows up on a subsequent run.
+    if (state.run_with_tr_switch) {
+        if (tr_switch_init(&state.tr_switch) == 0) {
+            state.have_tr_switch = 1;
+        } else {
+            fprintf(stderr,
+                    "T/R switch: could not open %s (skipping; "
+                    "pass --without-tr-switch to silence)\n",
+                    state.tr_switch.device_filename
+                        ? state.tr_switch.device_filename : "?");
+        }
         // Check that we can control the antenna position
         // antenna_rotator_result = antenna_rotator_command(&state.antenna_rotator, ANTENNA_ROTATOR_STATUS, NULL, NULL);
         // if (antenna_rotator_result != ANTENNA_ROTATOR_OK) {
@@ -578,6 +658,14 @@ int main(int argc, char **argv)
         UTC_Calendar_Now(&utc, &tv);
         jul_utc = Julian_Date(&utc, &tv);
         update_satellite_position(&state.prediction, jul_utc);
+
+        // Drain whatever the T/R switch has emitted since the last
+        // tick. Non-blocking; the firmware emits one heartbeat per
+        // ~2.5 s, so 5 ticks pass between updates at the 500 ms loop
+        // cadence and most ticks read zero bytes.
+        if (state.have_tr_switch) {
+            tr_switch_pump(&state.tr_switch, monotonic_seconds());
+        }
 
         /* Calculate Doppler shift */
         if (state.radio.doppler_correction_enabled) {
@@ -828,6 +916,10 @@ int main(int argc, char **argv)
         // rot_cleanup(state.rot);
     }
 
+    if (state.have_tr_switch) {
+        tr_switch_disconnect(&state.tr_switch);
+    }
+
     return 0;
 }
 
@@ -875,6 +967,13 @@ int apply_args(state_t *state, int argc, char **argv, double jul_utc)
     state->antenna_rotator.serial_speed = B600;
     state->antenna_rotator.fixed_target = 0;
 
+    // T/R antenna switch defaults. Auto-probe is on by default;
+    // failure is a one-line stderr warning, not an error.
+    state->run_with_tr_switch = 1;
+    state->have_tr_switch     = 0;
+    state->tr_switch.device_filename = "/dev/ttyACM0";
+    state->tr_switch.serial_speed    = B115200;
+
     // Default to recording audio
     state->audio.audio_record = 1;
     state->audio.audio_output_file_basename = "session/session_pcm_audio";
@@ -899,6 +998,16 @@ int apply_args(state_t *state, int argc, char **argv, double jul_utc)
             state->n_options++;
             state->run_with_radio = 1;
             state->run_with_antenna_rotator = 1;
+        } else if (strcmp("--without-tr-switch", argv[i]) == 0) {
+            state->n_options++;
+            state->run_with_tr_switch = 0;
+        } else if (strncmp("--tr-switch-device=", argv[i], 19) == 0) {
+            state->n_options++;
+            if (strlen(argv[i]) < 20) {
+                fprintf(stderr, "Unable to parse %s\n", argv[i]);
+                return EXIT_FAILURE;
+            }
+            state->tr_switch.device_filename = argv[i] + 19;
         } else if (strncmp("--tle=", argv[i], 6) == 0) {
             state->n_options++;
             if (strlen(argv[i]) < 7) {

--- a/state.h
+++ b/state.h
@@ -26,6 +26,7 @@
 #include "radio.h"
 #include "prediction.h"
 #include "telemetry.h"
+#include "tr_switch.h"
 
 #include <stdint.h>
 #include <termios.h>
@@ -63,6 +64,12 @@ typedef struct state
     antenna_rotator_t antenna_rotator;
     int run_with_antenna_rotator;
     int have_antenna_rotator;
+    // T/R antenna switch (USB-CDC, default /dev/ttyACM0).
+    // run_with_tr_switch defaults to 1: we auto-probe the device on
+    // start. Absent hardware is a one-line warning, not an error.
+    tr_switch_t tr_switch;
+    int run_with_tr_switch;
+    int have_tr_switch;
     // Audio
     audio_t audio;
     // Telemetry 

--- a/tr_switch.c
+++ b/tr_switch.c
@@ -1,0 +1,250 @@
+/*
+
+   Simple Satellite Operations  tr_switch.c
+
+   See tr_switch.h for the on-wire contract this driver implements.
+
+   Copyright (C) 2026  Johnathan K Burchill
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "tr_switch.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
+
+static int tr_switch_write_char(tr_switch_t *s, char c)
+{
+    if (s == NULL || !s->connected) return -1;
+    ssize_t n = write(s->fd, &c, 1);
+    return (n == 1) ? 0 : -1;
+}
+
+// Pull the substring after `needle=` from `line` up to the next space
+// or end-of-line, copy into `out` (truncating to cap-1 bytes), and
+// return a pointer to the value (inside line) or NULL when the key is
+// absent. The needle should include the trailing '='.
+static const char *find_kv(const char *line, const char *needle,
+                           char *out, size_t cap)
+{
+    if (out == NULL || cap == 0) return NULL;
+    out[0] = '\0';
+    const char *p = strstr(line, needle);
+    if (p == NULL) return NULL;
+    p += strlen(needle);
+    size_t i = 0;
+    while (p[i] != '\0' && p[i] != ' ' && p[i] != '\r' && p[i] != '\n'
+           && i + 1 < cap) {
+        out[i] = p[i];
+        ++i;
+    }
+    out[i] = '\0';
+    return p;
+}
+
+// Parse a complete line. Heartbeat lines look like
+//   [12345] [ INFO ] Heartbeat: state=RX mode=AUTO
+// with an optional `last_tx_ago_s=<sec>.<ms>` (or `=never`) field
+// appended by a future firmware release. Anything else (boot banner,
+// log-level ack, watchdog notice, debug "TX Sensed!" etc.) is
+// silently dropped.
+static void parse_line(tr_switch_t *s, const char *line, double t_now)
+{
+    if (s == NULL || line == NULL) return;
+    const char *hb = strstr(line, "Heartbeat:");
+    if (hb == NULL) return;
+
+    char state_buf[TR_SWITCH_STATE_MAX] = {0};
+    char mode_buf [TR_SWITCH_MODE_MAX]  = {0};
+    if (find_kv(hb, "state=", state_buf, sizeof state_buf) == NULL) return;
+    if (find_kv(hb, "mode=",  mode_buf,  sizeof mode_buf)  == NULL) return;
+
+    snprintf(s->state_str, sizeof s->state_str, "%s", state_buf);
+    snprintf(s->mode_str,  sizeof s->mode_str,  "%s", mode_buf);
+
+    // Optional last_tx_ago_s field. Tolerate three cases: absent,
+    // "never", and a numeric "<s>.<ms>" or "<s>" string.
+    char age_buf[32] = {0};
+    if (find_kv(hb, "last_tx_ago_s=", age_buf, sizeof age_buf) != NULL) {
+        if (strcmp(age_buf, "never") == 0) {
+            // Use +inf so the UI can render "never" as "—" without
+            // colliding with a real, very-large age value.
+            s->last_tx_ago_s = INFINITY;
+        } else {
+            // sscanf returns 1 on a successful parse; on failure the
+            // field is left as whatever it was before. Mark it NAN
+            // so the UI shows "—" rather than a stale number.
+            double v = NAN;
+            if (sscanf(age_buf, "%lf", &v) == 1) {
+                s->last_tx_ago_s = v;
+            } else {
+                s->last_tx_ago_s = NAN;
+            }
+        }
+    }
+    // If the field is absent the old value (NAN at init) is preserved.
+
+    s->t_last_heartbeat = t_now;
+    s->heartbeat_count++;
+}
+
+int tr_switch_init(tr_switch_t *s)
+{
+    if (s == NULL || s->device_filename == NULL) return -1;
+    s->connected        = 0;
+    s->fd               = -1;
+    s->rx_len           = 0;
+    s->state_str[0]     = '\0';
+    s->mode_str [0]     = '\0';
+    s->last_tx_ago_s    = NAN;
+    s->t_last_byte      = 0.0;
+    s->t_last_heartbeat = 0.0;
+    s->heartbeat_count  = 0;
+
+    // O_NONBLOCK keeps open() from hanging on a CDC modem that hasn't
+    // asserted DCD yet, and keeps the subsequent reads non-blocking
+    // even though the FD inherits the flag.
+    int fd = open(s->device_filename, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) {
+        // Caller logs; we stay silent so the warning isn't duplicated.
+        return -1;
+    }
+
+    struct termios tty;
+    memset(&tty, 0, sizeof tty);
+    if (tcgetattr(fd, &tty) != 0) {
+        close(fd);
+        return -1;
+    }
+    cfsetospeed(&tty, s->serial_speed ? s->serial_speed : B115200);
+    cfsetispeed(&tty, s->serial_speed ? s->serial_speed : B115200);
+
+    // Raw 8N1, no flow control. USB-CDC ignores most of this but the
+    // raw-mode bits matter so we don't process backspace / signal
+    // characters.
+    tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8;
+    tty.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP
+                     | INLCR | IGNCR | ICRNL | IXON);
+    tty.c_lflag = 0;
+    tty.c_oflag = 0;
+    tty.c_cc[VMIN]  = 0;
+    tty.c_cc[VTIME] = 0;
+
+    tty.c_cflag |= (CLOCAL | CREAD);
+    tty.c_cflag &= ~(PARENB | PARODD);
+    tty.c_cflag &= ~CSTOPB;
+    tty.c_cflag &= ~CRTSCTS;
+
+    if (tcsetattr(fd, TCSANOW, &tty) != 0) {
+        close(fd);
+        return -1;
+    }
+    tcflush(fd, TCIOFLUSH);
+
+    s->fd        = fd;
+    s->tty       = tty;
+    s->connected = 1;
+
+    // Wake the firmware: switch to LOG_INFO so heartbeats start
+    // flowing, then take serial-override AUTO so the TX detector
+    // drives K1/K2 regardless of the physical slide switch.
+    tr_switch_set_log_level  (s, 1);
+    tr_switch_set_serial_mode(s, 'a');
+    return 0;
+}
+
+void tr_switch_disconnect(tr_switch_t *s)
+{
+    if (s == NULL) return;
+    if (s->connected) {
+        // Best-effort: hand the firmware back to its slide switch
+        // before we drop the link.
+        tr_switch_set_serial_mode(s, 's');
+        close(s->fd);
+    }
+    s->connected = 0;
+    s->fd        = -1;
+}
+
+void tr_switch_pump(tr_switch_t *s, double t_now)
+{
+    if (s == NULL || !s->connected) return;
+    // Drain whatever is available. The FD is non-blocking so a read
+    // returning -1/EAGAIN just means "no bytes for now".
+    for (;;) {
+        char chunk[128];
+        ssize_t n = read(s->fd, chunk, sizeof chunk);
+        if (n < 0) {
+            // EAGAIN/EWOULDBLOCK = no bytes; anything else = drop the
+            // link and let the operator restart sso.
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                tr_switch_disconnect(s);
+            }
+            return;
+        }
+        if (n == 0) return;
+        s->t_last_byte = t_now;
+        // Append into rx_buf, splitting on '\n'. Overflow strategy:
+        // when a single line exceeds the buffer, drop the trailing
+        // chunk and keep enough head to find the eventual '\n' — the
+        // firmware never emits long lines, so this is defensive.
+        for (ssize_t i = 0; i < n; ++i) {
+            char c = chunk[i];
+            if (c == '\r') continue;
+            if (c == '\n') {
+                s->rx_buf[s->rx_len] = '\0';
+                parse_line(s, s->rx_buf, t_now);
+                s->rx_len = 0;
+                continue;
+            }
+            if (s->rx_len + 1 >= sizeof s->rx_buf) {
+                // Reset and look for the next newline.
+                s->rx_len = 0;
+                continue;
+            }
+            s->rx_buf[s->rx_len++] = c;
+        }
+    }
+}
+
+int tr_switch_set_log_level(tr_switch_t *s, int level)
+{
+    if (level < 0 || level > 3) return -1;
+    return tr_switch_write_char(s, (char)('0' + level));
+}
+
+int tr_switch_set_serial_mode(tr_switch_t *s, char serial_mode)
+{
+    if (serial_mode != 't' && serial_mode != 'r'
+        && serial_mode != 'a' && serial_mode != 's') return -1;
+    return tr_switch_write_char(s, serial_mode);
+}
+
+int tr_switch_is_stale(const tr_switch_t *s, double t_now)
+{
+    if (s == NULL || !s->connected) return 0;
+    if (s->t_last_heartbeat <= 0.0) {
+        // Allow a grace window after open: only flag stale once a
+        // full stale-window has elapsed without ever seeing a beat.
+        return (t_now - s->t_last_byte) > TR_SWITCH_STALE_AFTER_S
+            && s->t_last_byte > 0.0;
+    }
+    return (t_now - s->t_last_heartbeat) > TR_SWITCH_STALE_AFTER_S;
+}

--- a/tr_switch.h
+++ b/tr_switch.h
@@ -1,0 +1,106 @@
+/*
+
+   Simple Satellite Operations  tr_switch.h
+
+   Host-side driver for the CTS UHF RX/TX antenna switch
+   (CalgaryToSpace/CTS-Ground-Station-UHF-Antenna-Switch, RP2040-Zero
+   firmware speaking USB-CDC over /dev/ttyACM0).
+
+   The firmware boots silent at log level 0. After open we send '1'
+   to enable LOG_INFO heartbeats (cadence ~2500 ms) and 'a' to put
+   the switch in serial-override AUTO so its TX detector — rather than
+   the physical slide switch — drives the K1/K2 relays. From then on
+   tr_switch_pump() drains complete '\n'-terminated lines, parses any
+   line that begins with "Heartbeat: ", and stashes the latest
+   state/mode/last_tx_ago_s.
+
+   Copyright (C) 2026  Johnathan K Burchill
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef TR_SWITCH_H
+#define TR_SWITCH_H
+
+#include <termios.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#define TR_SWITCH_RX_BUF_BYTES 256
+#define TR_SWITCH_STATE_MAX     8     // "TX" / "RX"
+#define TR_SWITCH_MODE_MAX     16     // "AUTO" / "FORCE_TX" / "FORCE_RX" / "INVALID"
+
+// Firmware heartbeat cadence is 2500 ms. Treat the link as stale once
+// we go 3x that without a fresh line.
+#define TR_SWITCH_HEARTBEAT_PERIOD_S  2.5
+#define TR_SWITCH_STALE_AFTER_S       (3.0 * TR_SWITCH_HEARTBEAT_PERIOD_S)
+
+typedef struct tr_switch {
+    // Caller fills these before tr_switch_init().
+    const char *device_filename;     // e.g. "/dev/ttyACM0"
+    speed_t     serial_speed;        // B115200 — USB-CDC ignores it,
+                                     //          but termios still needs a value
+
+    // Set by tr_switch_init() / tr_switch_disconnect().
+    int            fd;
+    int            connected;
+    struct termios tty;
+
+    // Partial-line assembly buffer for the non-blocking reader.
+    char   rx_buf[TR_SWITCH_RX_BUF_BYTES];
+    size_t rx_len;
+
+    // Latest parsed heartbeat fields. Empty strings until the first
+    // heartbeat lands.
+    char   state_str[TR_SWITCH_STATE_MAX];
+    char   mode_str [TR_SWITCH_MODE_MAX];
+    // last_tx_ago_s is from the (future) firmware extension; until
+    // that lands the field is absent in the line and this stays NAN.
+    // The literal "never" maps to +infinity so the UI can format it
+    // as "—" without colliding with a real, very-large age.
+    double last_tx_ago_s;
+    // Monotonic seconds, set on every line received and on every
+    // successful parse. The UI compares against the current monotonic
+    // time to detect a stale link.
+    double t_last_byte;
+    double t_last_heartbeat;
+    // Count of heartbeat lines successfully parsed since open. Useful
+    // for the panel ("seen N") and for tests.
+    unsigned long heartbeat_count;
+} tr_switch_t;
+
+// Open the device, drop into raw 8N1, send '1' + 'a'. Returns 0 on
+// success, nonzero on failure. Failure is non-fatal — the caller
+// should leave the switch as "not connected" and keep running.
+int  tr_switch_init        (tr_switch_t *s);
+void tr_switch_disconnect  (tr_switch_t *s);
+
+// Non-blocking read pump. Drains whatever bytes are available, runs
+// any complete lines through the heartbeat parser, and updates the
+// status fields. Cheap to call every tick.
+void tr_switch_pump        (tr_switch_t *s, double t_now);
+
+// Operator commands. Each writes a single character; the firmware
+// parser is single-character with no terminator.
+//   level: 0..3
+//   serial_mode: 't' / 'r' / 'a' / 's' (force TX / RX / AUTO / clear)
+int  tr_switch_set_log_level   (tr_switch_t *s, int level);
+int  tr_switch_set_serial_mode (tr_switch_t *s, char serial_mode);
+
+// True if no heartbeat has landed within TR_SWITCH_STALE_AFTER_S.
+// Returns 0 when not connected (so callers can treat the link as
+// "no data, but not specifically stale").
+int  tr_switch_is_stale    (const tr_switch_t *s, double t_now);
+
+#endif // TR_SWITCH_H


### PR DESCRIPTION
## Summary

Brings the CTS UHF T/R antenna switch into the operator UI.

- Auto-probes `/dev/ttyACM0` on start; absence is a one-line warning, not an error.
- After open, sends `'1'` to enable the firmware's INFO heartbeat (roughly every 2.5 s) and `'a'` to put the switch in serial-override AUTO so its TX detector drives the K1/K2 relays.
- Parses each `Heartbeat: state=... mode=... [last_tx_ago_s=...]` line into a small status struct.
- New operator panel (drawn below the rotator block) reports the connection, the RF state, the mode, and the seconds since the last detected TX. Anything other than `RX` / `AUTO` / fresh heartbeat is coloured.
- `--tr-switch-device=<path>` lets the operator point at a different node; `--without-tr-switch` skips the probe entirely.

The `last_tx_ago_s` field is the future firmware extension — until that PR lands the field is absent in the heartbeat and the panel prints `--`. The parser tolerates both old and new firmware.

## Files

- new `tr_switch.{h,c}` — termios open, non-blocking pump, line splitter, heartbeat parser.
- `state.h` — three new fields next to the rotator's (`tr_switch_t`, `run_with_tr_switch`, `have_tr_switch`).
- `main.c` — defaults init, two CLI flags, help text, startup probe, per-tick pump, render extension in `report_status`, shutdown close.
- `CMakeLists.txt` — wires `tr_switch.c` into the `simple_sat_ops` target.

## Test plan

- [ ] On the Linux ground-station box, build `simple_sat_ops` from this branch.
- [ ] Run with no T/R switch plugged in. Expect a one-line warning on stderr; the new panel reads `T/R switch  : * not connected *`; everything else runs.
- [ ] Plug the switch in (with the slide switch on any position). Re-run. After ~3 s the panel should populate with `state` and `mode`. The mode should be `AUTO` regardless of the physical switch — that's the serial override at work.
- [ ] Override `--tr-switch-device=/dev/ttyACM1` (or whatever it enumerates as) to confirm the flag path.
- [ ] Pass `--without-tr-switch` and confirm no probe attempt is made.
- [ ] (After the firmware PR lands) commit a small dummy TX, watch the `last TX` line cycle from `--` to `0.x s ago` and grow on subsequent heartbeats.

A follow-up firmware PR will extend the heartbeat with `last_tx_ago_s=<float>|never`. This change is forward-compatible with that addition and reverse-compatible with the heartbeat as it ships today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)